### PR TITLE
Reject when attempting to save a deleted model

### DIFF
--- a/src/data/Model.js
+++ b/src/data/Model.js
@@ -480,6 +480,16 @@ let Model = Class.extend({
     let saveQueue = this.__meta.saveQueue
 
     return saveQueue.add(() => {
+      if (get(this, 'isDeleting')) {
+        const errMsg = 'Trying to save model but model is currently being deleted'
+        return Promise.reject(new Error(errMsg))
+      }
+
+      if (this.isDestroyed) {
+        const errMsg = 'Trying to save model but model has been destroyed.'
+        return Promise.reject(new Error(errMsg))
+      }
+
       let isNew = get(this, 'isNew')
       set(this, 'isSaving', true)
 


### PR DESCRIPTION
@gigafied I ran into issues where a model was being saved after it had been deleted/destroyed. This change seems like the right way of dealing with the issue at this level, but it doesn't fix any of the consumers - they'll still crash because no consumer expects `save` to reject. Another possible approach is to `return Promise.resolve(this)` or something similar. It's not really the right behavior, and it won't fix all consumers, but it might save some headaches.

Let me know what you think