### PR TITLE
Add support for validation [UFPS-782]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ thoughts.md
 tmp
 coverage.html
 package-lock.json
+.idea

--- a/src/data/attr.js
+++ b/src/data/attr.js
@@ -83,6 +83,9 @@ module.exports = function make (type, opts) {
     return make(type, opts)
   }
 
+  if (opts.validation) attr.validation = opts.validation
+  else if (type === Boolean) attr.validation = { type: 'boolean' }
+
   return attr
 }
 

--- a/src/data/hasMany.js
+++ b/src/data/hasMany.js
@@ -154,5 +154,7 @@ module.exports = function make (mKey, opts) {
     return make(mKey, opts)
   }
 
+  if (opts.validation) hasMany.validation = opts.validation
+
   return hasMany
 }

--- a/src/data/hasOne.js
+++ b/src/data/hasOne.js
@@ -118,5 +118,7 @@ module.exports = function make (mKey, opts) {
     return make(mKey, opts)
   }
 
+  if (opts.validation) hasOne.validation = opts.validation
+
   return hasOne
 }


### PR DESCRIPTION
Add support for a new `validation` property that will facilitate [JSON Schema Validation](http://json-schema.org/latest/json-schema-validation.html). This allows validation rules to be defined directly on model properties (although for boolean properties decal can add the validation to eliminate boilerplate).

The corresponding UFP pull request is [here](https://github.com/ubiquiti/unifi-protect/pull/990).