### PR TITLE
fix: The properties to watch of computed property should be an array

### DIFF
--- a/src/data/Model.js
+++ b/src/data/Model.js
@@ -110,7 +110,7 @@ let Model = Class.extend({
   */
   adapter: computed(function () {
     return this.store.getAdapterFor(this.constructor)
-  }, 'store'),
+  }, ['store']),
 
   /**
   The modelKey you want to use for the model. This will likely influence your adapter.
@@ -203,7 +203,7 @@ let Model = Class.extend({
 
   isDirty: computed(function () {
     return !!get(this, 'dirtyAttributes.length')
-  }, 'dirtyAttributes.length'),
+  }, ['dirtyAttributes.length']),
 
   /**
   Opposite of isDirty.
@@ -215,7 +215,7 @@ let Model = Class.extend({
 
   isClean: computed(function () {
     return !get(this, 'isDirty')
-  }, 'isDirty'),
+  }, ['isDirty']),
 
   /**
   Is the record new? Determined by the existence of a primary key value.
@@ -227,7 +227,7 @@ let Model = Class.extend({
 
   isNew: computed(function () {
     return !get(this, 'pk')
-  }, 'pk'),
+  }, ['pk']),
 
   /**
   Get the primary key value of the record.

--- a/src/utils/computed.js
+++ b/src/utils/computed.js
@@ -14,7 +14,7 @@ let Person = decal.Object.extend({
     lastLame : '',
     fullName : decal.computed(function () {
         return this.firstName + ' ' + this.lastName
-    }, 'firstName', 'lastName')
+    }, ['firstName', 'lastName'], opts)
 })
 
 personInstance = Person.create({firstName : 'Jane', lastName : 'Doe'})
@@ -43,6 +43,10 @@ let personInstance = decal.Object.create({
             this.lastName = val[1] || ''
             return val.join(' ')
         }
+    },
+    opts : {
+      description: 'Full name of this person',
+      objType: String
     })
 })
 
@@ -62,9 +66,17 @@ can be specified after the getter.
 If you just want getter/setter support for a property you can specify an
 empty array for the `watch` property or not define it at all.
 
+**METHOD 1:**
 @method computed
 @param {Function} fn The getter for the computed property.
-@param {String} ...watch The properties to watch.
+@param {Array} watch The array of properties to watch.
+@param {Object} opts Options for the computed property
+@return {ComputedProperty}
+
+**METHOD 2:**
+@method computed
+@param {Object} object The object containing the [set/get/watch] property.
+@param {Object} opts Options for the computed property
 @return {ComputedProperty}
 */
 
@@ -76,7 +88,14 @@ module.exports = function (o) {
   if (isFunction(o)) {
     o = {
       watch: arguments[1],
-      get: o
+      get: o,
+      __meta: {
+        opts: arguments[2]
+      }
+    }
+  } else {
+    o.__meta = {
+      opts: arguments[1]
     }
   }
 
@@ -85,7 +104,6 @@ module.exports = function (o) {
   }
 
   o.watch = o.hasOwnProperty('watch') ? [].concat(o.watch) : []
-  o.__meta = {}
   o.__isComputed = true
 
   o.meta = function (m) {

--- a/tests/decal/core/Object/computed.js
+++ b/tests/decal/core/Object/computed.js
@@ -1,5 +1,24 @@
 describe('computed properties', function () {
-  it('should be able to watch computed properties for changes', function (done) {
+  it('should be able to watch computed properties for changes (METHOD 1)', function (done) {
+    let a = decal.Object.create({
+      num1: 1,
+      num2: 2,
+      sum: decal.computed(function () {
+        return this.num1 + this.num2
+      }, ['num1', 'num2'])
+    })
+
+    a.watch('sum', function () {
+      expect(a.sum).to.equal(15)
+      a.destroy()
+      done()
+    })
+
+    a.num1 = 5
+    a.num2 = 10
+  })
+
+  it('should be able to watch computed properties for changes (METHOD 2)', function (done) {
     let a = decal.Object.create({
       num1: 1,
       num2: 2,
@@ -20,5 +39,45 @@ describe('computed properties', function () {
 
     a.num1 = 5
     a.num2 = 10
+  })
+
+  it('should be able to watch computed properties if only one property is changed', function (done) {
+    let a = decal.Object.create({
+      num1: 1,
+      num2: 2,
+      sum: decal.computed(function () {
+        return this.num1 + this.num2
+      }, ['num1', 'num2'])
+    })
+
+    a.watch('sum', function () {
+      expect(a.sum).to.equal(11)
+      a.destroy()
+      done()
+    })
+
+    a.num2 = 10
+  })
+
+  it('should be able to watch computed properties if only one property is changed', function (done) {
+    let a = decal.Object.create({
+      num1: 1,
+      num2: 2,
+      sum: decal.computed({
+        watch: ['num1', 'num2'],
+
+        get: function () {
+          return this.num1 + this.num2
+        }
+      })
+    })
+
+    a.watch('sum', function () {
+      expect(a.sum).to.equal(7)
+      a.destroy()
+      done()
+    })
+
+    a.num1 = 5
   })
 })

--- a/tests/decal/data/Model/hasMany.js
+++ b/tests/decal/data/Model/hasMany.js
@@ -23,15 +23,15 @@ describe('hasMany', function () {
 
       canRead: decal.computed(function () {
         return this.get('value') >= 1
-      }, 'value'),
+      }, ['value']),
 
       canWrite: decal.computed(function () {
         return this.get('value') >= 2
-      }, 'value'),
+      }, ['value']),
 
       canDelete: decal.computed(function () {
         return this.get('value') >= 3
-      }, 'value')
+      }, ['value'])
     })
 
     Post = decal.Model.extend({


### PR DESCRIPTION
If we create a computed property with more than one properties to watch by [method 1](https://github.com/gigafied/decal.js/blob/master/src/utils/computed.js#L9-L18), only first property will trigger the watch event, here is an unit test to describe the scenario, which will fail for sure.
```js
describe('computed properties', function () {
  it.only('should be able to watch computed properties for changes', function (done) {
    let a = decal.Object.create({
      num1: 1,
      num2: 2,
      sum: decal.computed(function () {
          return this.num1 + this.num2
        }, 'num1', 'num2')
      })
    a.watch('sum', function () {
      expect(a.sum).to.equal(11)
      a.destroy()
      done()
    })
    a.num2 = 10
  })
})
```
```
  Decal.Object
    computed properties
      1) should be able to watch computed properties for changes


  0 passing (2s)
  1 failing

  1) Decal.Object computed properties should be able to watch computed properties for changes:
     Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
```

I think the properties to watch should be an array if I use the method 2 to create.
I also introduce a `option` parameter for computed property, it might be useful if I want to add some metadata like description for this computed property.
